### PR TITLE
Fix Go module name to allow importing as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,29 @@ This is an academic, unaudited PoC implementation of the ZKLP protocol, assompan
 
 Initialize h3 submodule.
 
-```
+```bash
 git submodule init
 git submodule update
 ```
 
 Execute floating-point tests. Test cases are generated from [Berkeley TestFloat](https://github.com/ucb-bar/berkeley-testfloat-3) to ensure IEEE-754 compliance.
 
-```
+```bash
 cd float
 go test -test.v
 ```
 
 Execute ZKLP tests. Test cases are generate for all resolutions, with logarithmic steps towards the hexagon boundary.
 
-```
+```bash
 cd loc2index32
 go test -test.v
+```
+
+## Installation as a dependency
+
+To add zk-Location as a dependency in your project, run
+
+```bash
+go get github.com/tumberger/zk-Location
 ```

--- a/float/float.go
+++ b/float/float.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/consensys/gnark/frontend"
 
-	"gnark-float/gadget"
-	"gnark-float/hint"
-	"gnark-float/util"
+	"github.com/tumberger/zk-Location/gadget"
+	"github.com/tumberger/zk-Location/hint"
+	"github.com/tumberger/zk-Location/util"
 )
 
 type Context struct {

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -1,7 +1,7 @@
 package gadget
 
 import (
-	"gnark-float/hint"
+	"github.com/tumberger/zk-Location/hint"
 	"math/big"
 
 	"github.com/consensys/gnark/frontend"
@@ -35,14 +35,14 @@ func (t *PowersOfTwo) commit(api frontend.API) error {
 }
 
 type IntGadget struct {
-	api               frontend.API
-	rangechecker      *CommitChecker
-	pow2              *PowersOfTwo
-	range_size        uint
-	pow2_size         uint
+	api                      frontend.API
+	rangechecker             *CommitChecker
+	pow2                     *PowersOfTwo
+	range_size               uint
+	pow2_size                uint
 	num_range_decompositions uint
-	num_range_chunks  uint
-	num_pow2_queries  uint
+	num_range_chunks         uint
+	num_pow2_queries         uint
 }
 
 func New(api frontend.API, range_size uint, pow2_size uint) *IntGadget {
@@ -72,7 +72,7 @@ func (f *IntGadget) AssertBitLength(v frontend.Variable, bit_length uint, mode M
 			f.num_range_decompositions++
 		}
 		f.num_range_chunks += num_limbs
-		if mode == TightForUnknownRange && bit_length % f.range_size != 0 {
+		if mode == TightForUnknownRange && bit_length%f.range_size != 0 {
 			f.num_range_chunks++
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gnark-float
+module github.com/tumberger/zk-Location
 
 go 1.21.5
 

--- a/hint/hint.go
+++ b/hint/hint.go
@@ -1,7 +1,7 @@
 package hint
 
 import (
-	"gnark-float/util"
+	"github.com/tumberger/zk-Location/util"
 	"math"
 	"math/big"
 

--- a/loc2index32/loc2index32.go
+++ b/loc2index32/loc2index32.go
@@ -1,8 +1,8 @@
 package loc2index64
 
 import (
-	float "gnark-float/float"
-	util "gnark-float/util"
+	float "github.com/tumberger/zk-Location/float"
+	util "github.com/tumberger/zk-Location/util"
 
 	"math"
 	//"fmt"

--- a/loc2index32/loc2index32_test.go
+++ b/loc2index32/loc2index32_test.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"testing"
 
-	float "gnark-float/float"
-	"gnark-float/hint"
-	maths "gnark-float/math"
-	util "gnark-float/util"
+	float "github.com/tumberger/zk-Location/float"
+	"github.com/tumberger/zk-Location/hint"
+	maths "github.com/tumberger/zk-Location/math"
+	util "github.com/tumberger/zk-Location/util"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"

--- a/loc2index64/loc2index64.go
+++ b/loc2index64/loc2index64.go
@@ -1,8 +1,8 @@
 package loc2index64
 
 import (
-	float "gnark-float/float"
-	util "gnark-float/util"
+	float "github.com/tumberger/zk-Location/float"
+	util "github.com/tumberger/zk-Location/util"
 
 	"math"
 	//"fmt"

--- a/loc2index64/loc2index64_test.go
+++ b/loc2index64/loc2index64_test.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	float "gnark-float/float"
-	"gnark-float/hint"
-	util "gnark-float/util"
+	float "github.com/tumberger/zk-Location/float"
+	"github.com/tumberger/zk-Location/hint"
+	util "github.com/tumberger/zk-Location/util"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"

--- a/math/math.go
+++ b/math/math.go
@@ -1,7 +1,7 @@
 package math
 
 import (
-	float "gnark-float/float"
+	float "github.com/tumberger/zk-Location/float"
 
 	//"fmt"
 	"math"

--- a/math/math_test.go
+++ b/math/math_test.go
@@ -3,7 +3,7 @@ package math
 import (
 	"bufio"
 	"fmt"
-	"gnark-float/float"
+	"github.com/tumberger/zk-Location/float"
 	"math/big"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
Hi,

This PR fixes an issue where the project cannot be imported as a library dependency due to its Go module name.
This change updates the module name to ensure it is valid and usable as a dependency.
